### PR TITLE
Hotfix/draggable

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,17 @@
     "type": "git",
     "url": "https://github.com/harsohailB/ticker-symbol-search"
   },
+  "keywords": [
+    "react",
+    "typescript",
+    "library",
+    "stocks",
+    "tickers",
+    "fintech",
+    "crypto",
+    "finance",
+    "search"
+  ],
   "bugs": "https://github.com/harsohailB/ticker-symbol-search/issues",
   "dependencies": {
     "@material-ui/core": "^4.11.3",

--- a/src/container/DraggableWrapper.tsx
+++ b/src/container/DraggableWrapper.tsx
@@ -37,7 +37,7 @@ const DraggableWrapper = (props: { theme?: Theme; children: JSX.Element }) => {
     <ThemeProvider
       theme={props.theme ? { ...defaultTheme, ...props.theme } : defaultTheme}
     >
-      <Draggable disabled={isMobile} bounds="parent">
+      <Draggable disabled={isMobile}>
         <Wrapper>{props.children}</Wrapper>
       </Draggable>
     </ThemeProvider>


### PR DESCRIPTION
Removed parent boundaries from Draggable container to allow for free movement anywhere on the screen.

close #11 